### PR TITLE
Add tooltip for negative and remove positive if added class

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -48,6 +48,10 @@ export default function Home() {
     [key: string]: Box[];
   }>({});
   const [classes, setClasses] = useState(["negative", "positive"]);
+  const filterPositive = classes.length > 2;
+  const classesToShow = filterPositive
+    ? classes.filter((c) => c !== "positive")
+    : classes;
   const [isInferring, setIsInferring] = useState(false);
 
   async function onBoxAdded(box: Box, imageWidth: number, imageHeight: number) {
@@ -243,12 +247,13 @@ export default function Home() {
                   <div>
                     <div className="mb-5">
                       <ImageGrid
-                        classes={classes}
+                        classes={classesToShow}
                         images={images}
                         onImageClick={(image) => {
                           setSelectedImage(image);
                           setDialogOpen(true);
                         }}
+                        filterPositive={filterPositive}
                         boxes={userBoxes}
                         suggestedBoxes={suggestedBoxes}
                       />
@@ -292,12 +297,14 @@ export default function Home() {
       </main>
       {selectedImage && (
         <ImageDialog
-          classes={classes}
+          classes={classesToShow}
           setClasses={setClasses}
           imageFile={selectedImage}
           isOpen={isDialogOpen}
           onClose={handleDialogClose}
-          boxes={userBoxes[selectedImage.name] || []}
+          boxes={(userBoxes[selectedImage.name] || []).filter((box) =>
+            filterPositive ? box.cls !== "positive" : true,
+          )}
           onAddBox={onBoxAdded}
           suggestedBoxes={suggestedBoxes[selectedImage.name] || []}
         />

--- a/frontend/src/components/ImageDialog.tsx
+++ b/frontend/src/components/ImageDialog.tsx
@@ -261,20 +261,36 @@ const ImageDialog: React.FC<ImageDialogProps> = ({
       <DialogContent className="w-[80vw] h-[80vh] max-w-[1200px] max-h-[800px]">
         <div className="flex space-x-2 items-center">
           {classes.map((cls, index) => (
-            <Button
-              key={cls}
-              variant={currentClass === cls ? "default" : "outline"}
-              className={"flex items-center"}
-              onClick={() => setCurrentClass(cls)}
-            >
-              <span
-                className="w-4 h-4 rounded-full mr-2"
-                style={{
-                  backgroundColor: classColors[index % classColors.length],
-                }}
-              ></span>
-              {cls}
-            </Button>
+            <Tooltip>
+              <TooltipTrigger>
+                <Button
+                  key={cls}
+                  variant={currentClass === cls ? "default" : "outline"}
+                  className={"flex items-center"}
+                  onClick={() => setCurrentClass(cls)}
+                >
+                  <span
+                    className="w-4 h-4 rounded-full mr-2"
+                    style={{
+                      backgroundColor: classColors[index % classColors.length],
+                    }}
+                  ></span>
+                  {cls}
+                </Button>
+              </TooltipTrigger>
+              {cls === "negative" && (
+                <TooltipContent>
+                  Negative class is used to mark areas that do not contain any
+                  of your classes.
+                </TooltipContent>
+              )}
+              {cls === "positive" && (
+                <TooltipContent>
+                  Positive class is a default class for testing that will be
+                  removed if you add a custom class.
+                </TooltipContent>
+              )}
+            </Tooltip>
           ))}
           <form onSubmit={handleAddClass} className="flex space-x-2">
             <Input
@@ -283,6 +299,7 @@ const ImageDialog: React.FC<ImageDialogProps> = ({
               onChange={(e) => setNewClass(e.target.value)}
               placeholder="Add new class"
               className="w-32 ml-5"
+              autoFocus
             />
             <Button type="submit" variant="outline">
               Add

--- a/frontend/src/components/ImageDialog.tsx
+++ b/frontend/src/components/ImageDialog.tsx
@@ -1,9 +1,16 @@
-import React, { useState, useEffect, useRef, useCallback } from "react";
+import React, {
+  useState,
+  useEffect,
+  useRef,
+  useCallback,
+  Fragment,
+} from "react";
 import { Box } from "@/lib/types";
 import { Button } from "./ui/button";
 import { Dialog, DialogContent } from "./ui/dialog";
 import { Input } from "./ui/input"; // Add this import
 import { useResizeObserver } from "@/hooks/useResizeObserver";
+import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 
 export const classColors = [
   "red",
@@ -17,7 +24,7 @@ export const classColors = [
 
 interface ImageDialogProps {
   classes: string[];
-  setClasses: (classes: string[]) => void;
+  setClasses: React.Dispatch<React.SetStateAction<string[]>>;
   imageFile: File;
   isOpen: boolean;
   onClose: () => void;
@@ -43,10 +50,16 @@ const ImageDialog: React.FC<ImageDialogProps> = ({
   const [startPos, setStartPos] = useState({ x: 0, y: 0 });
   const [currentBox, setCurrentBox] = useState<Box | null>(null);
   const [canvasSize, setCanvasSize] = useState({ width: 0, height: 0 });
-  const [currentClass, setCurrentClass] = useState("positive");
+  const [currentClass, setCurrentClass] = useState(classes[1]);
   const [newClass, setNewClass] = useState("");
   const containerRef = useRef<HTMLDivElement>(null);
   const containerSize = useResizeObserver(containerRef);
+
+  useEffect(() => {
+    if (!classes.includes(currentClass)) {
+      setCurrentClass(classes[1]);
+    }
+  }, [classes]);
 
   useEffect(() => {
     if (containerSize && imageRef.current) {
@@ -238,7 +251,7 @@ const ImageDialog: React.FC<ImageDialogProps> = ({
   const handleAddClass = (e: React.FormEvent) => {
     e.preventDefault();
     if (newClass && !classes.includes(newClass)) {
-      setClasses([...classes, newClass]);
+      setClasses((_c) => [..._c, newClass]);
       setNewClass("");
     }
   };

--- a/frontend/src/components/ImageGrid.tsx
+++ b/frontend/src/components/ImageGrid.tsx
@@ -73,14 +73,14 @@ const ImageGrid: React.FC<ImageGridProps> = ({
               URL.revokeObjectURL((event.target as HTMLImageElement).src);
               drawBoxes(
                 image.name,
-                boxes[image.name].filter((box) =>
+                boxes[image.name]?.filter((box) =>
                   filterPositive ? box.cls != "positive" : true,
                 ),
                 "solid",
               );
               drawBoxes(
                 image.name,
-                suggestedBoxes[image.name].filter((box) =>
+                suggestedBoxes[image.name]?.filter((box) =>
                   filterPositive ? box.cls != "positive" : true,
                 ),
                 "dashed",

--- a/frontend/src/components/ImageGrid.tsx
+++ b/frontend/src/components/ImageGrid.tsx
@@ -10,6 +10,7 @@ interface ImageGridProps {
   images: File[];
   onImageClick: (image: File) => void;
   suggestedBoxes: { [key: string]: Box[] };
+  filterPositive: boolean;
 }
 
 const ImageGrid: React.FC<ImageGridProps> = ({
@@ -18,6 +19,7 @@ const ImageGrid: React.FC<ImageGridProps> = ({
   classes,
   onImageClick,
   suggestedBoxes,
+  filterPositive,
 }) => {
   const canvasRefs = useRef<{ [key: string]: HTMLCanvasElement | null }>({});
   const imageRefs = useRef<{ [key: string]: HTMLImageElement | null }>({});
@@ -69,8 +71,20 @@ const ImageGrid: React.FC<ImageGridProps> = ({
             className="absolute inset-0 w-full h-full object-cover"
             onLoad={(event) => {
               URL.revokeObjectURL((event.target as HTMLImageElement).src);
-              drawBoxes(image.name, boxes[image.name], "solid");
-              drawBoxes(image.name, suggestedBoxes[image.name], "dashed");
+              drawBoxes(
+                image.name,
+                boxes[image.name].filter((box) =>
+                  filterPositive ? box.cls != "positive" : true,
+                ),
+                "solid",
+              );
+              drawBoxes(
+                image.name,
+                suggestedBoxes[image.name].filter((box) =>
+                  filterPositive ? box.cls != "positive" : true,
+                ),
+                "dashed",
+              );
             }}
           />
           <canvas

--- a/frontend/src/components/ui/tooltip.tsx
+++ b/frontend/src/components/ui/tooltip.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import * as React from "react";
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+
+import { cn } from "@/lib/utils";
+
+const Tooltip = ({
+  ...props
+}: React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Root>) => (
+  <TooltipPrimitive.Provider>
+    <TooltipPrimitive.Root delayDuration={400} {...props} />
+  </TooltipPrimitive.Provider>
+);
+Tooltip.displayName = TooltipPrimitive.Root.displayName;
+
+const TooltipTrigger = TooltipPrimitive.Trigger;
+
+const TooltipContent = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <TooltipPrimitive.Content
+    ref={ref}
+    className={cn(
+      "rounded-sm border-x-2 border-t-2 bg-white shadow-lg p-2",
+      className,
+    )}
+    {...props}
+  >
+    {children}
+    <TooltipPrimitive.Arrow className="fill-current text-background" />
+  </TooltipPrimitive.Content>
+));
+TooltipContent.displayName = TooltipPrimitive.Content.displayName;
+
+export { Tooltip, TooltipTrigger, TooltipContent };

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "format:write": "prettier --write '**/*.{js,ts,json,md,jsx,tsx,css,scss}'"
+    "format:write": "prettier --write '**/*.{js,ts,json,md,jsx,tsx,css,scss}'",
+    "dev": "cd frontend && npm run dev"
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
# Description

- adds tooltip for negative and positive classes
- when custom class is added, hide positive prompt and boxes from UI

Goal is to make it more obvious what negative/positive classes are for.


https://github.com/roboflow/visual-prompting/assets/6319317/8de05970-1711-42e8-98b2-49e03f606150

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested locally.